### PR TITLE
Add examples for python 3.8

### DIFF
--- a/things_you_are_probably_not_using_in_python_3_but_should/python 3 examples.ipynb
+++ b/things_you_are_probably_not_using_in_python_3_but_should/python 3 examples.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "Code examples from the [DataWhatNow](https://datawhatnow.com) blog on a [blog post abot Python 3](https://datawhatnow.com/things-you-are-probably-not-using-in-python-3-but-should).\n",
     "\n",
-    "## All the code examples are executed in python 3.7"
+    "## All the code examples are executed in python 3.8.0"
    ]
   },
   {
@@ -20,7 +20,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3.7.1 (default, Dec 14 2018, 19:28:38) \n",
+      "3.8.0 (default, Nov  6 2019, 21:49:08) \n",
       "[GCC 7.3.0]\n"
      ]
     }
@@ -116,7 +116,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/home/weenkus/Workspace/Projects/DataWhatNow-Codes/things_you_are_probably_not_using_in_python_3_but_should/post_sub_folder/happy_user\n"
+      "/home/weenkus/workspace/projects/data-what-now/things_you_are_probably_not_using_in_python_3_but_should/post_sub_folder/happy_user\n"
      ]
     }
    ],
@@ -239,7 +239,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Duration: 29.93897843360901s\n"
+      "Duration: 36.93609380722046s\n"
      ]
     }
    ],
@@ -274,7 +274,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Duration: 6.580352783203125e-05s\n"
+      "Duration: 0.00012874603271484375s\n"
      ]
     }
    ],
@@ -318,14 +318,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "python3.7\n",
+      "python3.8\n",
       "script.py\n",
       "['-n', '5', '-l', '15']\n"
      ]
     }
    ],
    "source": [
-    "py, filename, *cmds = \"python3.7 script.py -n 5 -l 15\".split()\n",
+    "py, filename, *cmds = \"python3.8 script.py -n 5 -l 15\".split()\n",
     "print(py)\n",
     "print(filename)\n",
     "print(cmds)"
@@ -397,7 +397,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<__main__.Armor object at 0x7f09d83f8ac8>\n"
+      "<__main__.Armor object at 0x7efe54262df0>\n"
      ]
     }
    ],
@@ -456,6 +456,67 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Underscores in Numeric Literals"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cost: 10000\n",
+      "Hex flag: 3674144760\n",
+      "Binary: 57\n"
+     ]
+    }
+   ],
+   "source": [
+    "cost = 10_000\n",
+    "print(f'Cost: {cost}')\n",
+    "\n",
+    "hex_flag = 0xDAFE_FFF8\n",
+    "print(f'Hex flag: {hex_flag}')\n",
+    "\n",
+    "binary = 0b_0011_1001\n",
+    "print(f'Binary: {binary}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Assignment Expressions - \"Walrus Operator\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The animal \"parrot\" has \"6\", letters!\n"
+     ]
+    }
+   ],
+   "source": [
+    "animals = ['bird', 'lion', 'bear', 'parrot']\n",
+    "\n",
+    "for animal in animals:\n",
+    "    if (len_animal := len(animal)) > 4:\n",
+    "        print(f'The animal \"{animal}\" has \"{len_animal}\", letters!')"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -479,7 +540,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.8.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Add examples that cover python 3.8 in [Things you’re probably not using in Python 3 – but should](https://datawhatnow.com/things-you-are-probably-not-using-in-python-3-but-should/) blog post.

![image](https://user-images.githubusercontent.com/9048523/71537069-b0542c80-28cb-11ea-87df-b4f29c9a9837.png)
